### PR TITLE
Search view到中央toggle以及下方初步的圖表

### DIFF
--- a/lib/search/match_info.dart
+++ b/lib/search/match_info.dart
@@ -14,6 +14,8 @@ class MatchInfo extends StatefulWidget {
 }
 
 class _MatchInfoState extends State<MatchInfo> {
+  int summaryOrBoxScoreIndex = 0;
+
   // 這一頁有用到Navigator.pop以及page route
   @override
   Widget build(BuildContext context) {
@@ -60,6 +62,7 @@ class _MatchInfoState extends State<MatchInfo> {
       ),
       body: Column(
         children: [
+          // toggle上方的所有物件
           Container(
             width: MediaQuery.of(context).size.width,
             height: 151,
@@ -145,15 +148,93 @@ class _MatchInfoState extends State<MatchInfo> {
               ],
             ),
             // todo: temporary border
-            decoration: const BoxDecoration(
-              border: Border(
-                top: BorderSide(color: Colors.black),
-                bottom: BorderSide(color: Colors.black),
-                left: BorderSide(color: Colors.black),
-                right: BorderSide(color: Colors.black)
-              ),
+            decoration: BoxDecoration(
+              border: Border.all(color: Colors.grey),
             ),
           ),
+          Neumorphic(
+            margin: const EdgeInsets.only(top: 25, bottom: 16, left: 13, right: 13),
+            style: NeumorphicStyle(
+              color: DuncColors.indicatorImportant,
+              depth: -3,
+              boxShape: NeumorphicBoxShape.roundRect(
+                  const BorderRadius.all(Radius.circular(20))),
+            ),
+            child: NeumorphicToggle(
+              height: 44,
+              padding: const EdgeInsets.all(5),
+              selectedIndex: summaryOrBoxScoreIndex,
+              duration: const Duration(milliseconds: 500),
+              movingCurve: Curves.easeInBack,
+              // 已被選擇的項目的樣式
+              thumb: Container(
+                foregroundDecoration: const BoxDecoration(
+                  color: DuncColors.secondaryCTAPurple,
+                ),
+              ),
+              // 沒被選擇的項目的樣式
+              style: const NeumorphicToggleStyle(
+                backgroundColor: DuncColors.mainBackground,  // 整個toggle背景
+                lightSource: LightSource(-0.6, -0.6),
+                borderRadius: BorderRadius.all(Radius.circular(20)), // 選中項目
+              ),
+              children: [
+                ToggleElement(
+                    foreground: const Center(
+                      child: Text(
+                        'Summary',
+                        style: TextStyle(
+                            color: Colors.white,
+                            fontFamily: 'Lexend',
+                            fontWeight: FontWeight.w400,
+                            fontSize: 15
+                        ),
+                      ),
+                    ),
+                    background: const Center(
+                      child: Text(
+                        'Summary',
+                        style: TextStyle(
+                            color: DuncColors.indicatorImportant,
+                            fontFamily: 'Lexend',
+                            fontWeight: FontWeight.w400,
+                            fontSize: 15
+                        ),
+                      ),
+                    )
+                ),
+                ToggleElement(
+                    foreground: const Center(
+                      child: Text(
+                        'Box Score',
+                        style: TextStyle(
+                            color: Colors.white,
+                            fontFamily: 'Lexend',
+                            fontWeight: FontWeight.w400,
+                            fontSize: 15
+                        ),
+                      ),
+                    ),
+                    background: const Center(
+                      child: Text(
+                        'Box Score',
+                        style: TextStyle(
+                            color: DuncColors.indicatorImportant,
+                            fontFamily: 'Lexend',
+                            fontWeight: FontWeight.w400,
+                            fontSize: 15
+                        ),
+                      ),
+                    )
+                )
+              ],
+              onChanged: (int index){
+                setState((){
+                  summaryOrBoxScoreIndex = index;
+                });
+              },
+            ),
+          )
         ],
       ),
     );

--- a/lib/search/match_info.dart
+++ b/lib/search/match_info.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_neumorphic/flutter_neumorphic.dart';
 import '../tools/colors.dart';
 import 'lib_match_info.dart';
+import 'package:fl_chart/fl_chart.dart';
 import 'example_match.dart';
 
 Set<String> _track = {};
@@ -14,9 +15,10 @@ class MatchInfo extends StatefulWidget {
 }
 
 class _MatchInfoState extends State<MatchInfo> {
+  // 這一頁有用到Navigator.pop以及page route
+
   int summaryOrBoxScoreIndex = 0;
 
-  // 這一頁有用到Navigator.pop以及page route
   @override
   Widget build(BuildContext context) {
     // id toward one single match
@@ -138,10 +140,10 @@ class _MatchInfoState extends State<MatchInfo> {
                 Text(
                   '${match.date.month}/${match.date.day}‧${match.place}',
                   style: const TextStyle(
-                    fontFamily: 'Lexend',
-                    fontWeight: FontWeight.w600,
-                    fontSize: 15,
-                    color: DuncColors.matchInfo
+                      fontFamily: 'Lexend',
+                      fontWeight: FontWeight.w600,
+                      fontSize: 15,
+                      color: DuncColors.matchInfo
                   ),
                 ),
                 const Spacer(flex: 4,)
@@ -152,6 +154,7 @@ class _MatchInfoState extends State<MatchInfo> {
               border: Border.all(color: Colors.grey),
             ),
           ),
+          // 中央toggle
           Neumorphic(
             margin: const EdgeInsets.only(top: 25, bottom: 16, left: 13, right: 13),
             style: NeumorphicStyle(
@@ -234,9 +237,113 @@ class _MatchInfoState extends State<MatchInfo> {
                 });
               },
             ),
+          ),
+          // toggle下方的所有物件
+          Flexible(
+            child: ListView(
+              padding: const EdgeInsets.only(left: 7, right: 7),
+              children: summaryOrBoxScoreIndex == 0 ? _summary(match) : _boxScore(match),
+            ),
           )
         ],
       ),
     );
   }
 }
+
+List<Widget> _summary(final Match match){
+  const TextStyle titleTextStyle = TextStyle(
+    color: DuncColors.matchInfo,
+    fontFamily: 'Lexend',
+    fontWeight: FontWeight.w600,
+    fontSize: 15
+  );
+  Container summaryTitle(final String title){
+    return Container(
+      alignment: Alignment.topLeft,
+      padding: const EdgeInsets.only(left: 17),
+      child: Column(
+        children: [
+          const SizedBox(height: 40,),
+          Text(
+            title,
+            style: titleTextStyle,
+          ),
+          const SizedBox(height: 19,)
+        ],
+      ),
+    );
+  }
+  return [
+    Neumorphic(
+      style: _summaryInfoCardStyle,
+      child: SizedBox(
+        height: 229,
+        child: Column(
+          children: [
+            SizedBox(
+              height: 59,
+            ),
+            // 圖表
+            Flexible(
+              child: LayoutBuilder(
+                builder: (context, boxConstrains){
+                  return SizedBox(
+                    width: boxConstrains.maxWidth - 96,
+                    height: boxConstrains.maxHeight - 30,
+                    child: LineChart(
+                        LineChartData(
+                            lineBarsData: List.generate(
+                                2,  // two teams
+                                    (teamIndex) {
+                                  return LineChartBarData(
+                                    spots: List.generate(
+                                        teamIndex == 0 ?
+                                        match.quarterScore1?.length ?? 0 : // return the value if it isn't null
+                                        match.quarterScore2?.length ?? 0,
+                                            (quarterIndex){
+                                          return FlSpot(
+                                              quarterIndex * 1.0,
+                                              (teamIndex == 0
+                                                  ? match.quarterScore1![quarterIndex]
+                                                  : match.quarterScore2![quarterIndex]
+                                              ) * 1.0
+                                          );
+                                        }
+                                    ),
+                                    color: teamIndex == 0
+                                        ? DuncColors.playoffs
+                                        : DuncColors.pointsMatch,
+                                    barWidth: 1,
+                                    shadow: const Shadow(
+                                        color: Color(0x298a8989),
+                                        offset: Offset(0, 10)
+                                    ),
+                                  );
+                                }
+                            )
+                        )
+                    ),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    ),
+    summaryTitle('兩隊比較')
+  ];
+}
+
+List<Widget> _boxScore(final Match match){
+  return [];
+}
+
+final _summaryInfoCardStyle = NeumorphicStyle(
+    color: DuncColors.mainBackground,
+    boxShape: NeumorphicBoxShape.roundRect(BorderRadius.circular(20)),
+    shadowLightColor: DuncColors.shadowLight,
+    shadowDarkColor: DuncColors.shadowDark,
+    depth: 4
+);

--- a/lib/search/match_info.dart
+++ b/lib/search/match_info.dart
@@ -275,6 +275,7 @@ List<Widget> _summary(final Match match){
     );
   }
   return [
+    // 各節比分
     Neumorphic(
       style: _summaryInfoCardStyle,
       child: SizedBox(
@@ -290,38 +291,77 @@ List<Widget> _summary(final Match match){
                 builder: (context, boxConstrains){
                   return SizedBox(
                     width: boxConstrains.maxWidth - 96,
-                    height: boxConstrains.maxHeight - 30,
                     child: LineChart(
                         LineChartData(
-                            lineBarsData: List.generate(
-                                2,  // two teams
-                                    (teamIndex) {
-                                  return LineChartBarData(
-                                    spots: List.generate(
-                                        teamIndex == 0 ?
-                                        match.quarterScore1?.length ?? 0 : // return the value if it isn't null
-                                        match.quarterScore2?.length ?? 0,
-                                            (quarterIndex){
-                                          return FlSpot(
-                                              quarterIndex * 1.0,
-                                              (teamIndex == 0
-                                                  ? match.quarterScore1![quarterIndex]
-                                                  : match.quarterScore2![quarterIndex]
-                                              ) * 1.0
-                                          );
-                                        }
-                                    ),
-                                    color: teamIndex == 0
-                                        ? DuncColors.playoffs
-                                        : DuncColors.pointsMatch,
-                                    barWidth: 1,
-                                    shadow: const Shadow(
-                                        color: Color(0x298a8989),
-                                        offset: Offset(0, 10)
-                                    ),
-                                  );
-                                }
+                          // 實際的資料點
+                          lineBarsData: List.generate(
+                              2,  // two teams
+                              (teamIndex) {
+                                return LineChartBarData(
+                                  spots: List.generate(
+                                      teamIndex == 0 ?
+                                      match.quarterScore1?.length ?? 0 : // return the value if it isn't null
+                                      match.quarterScore2?.length ?? 0,
+                                      (quarterIndex){
+                                        return FlSpot(
+                                            quarterIndex * 1.0,
+                                            (teamIndex == 0
+                                                ? match.quarterScore1![quarterIndex]
+                                                : match.quarterScore2![quarterIndex]
+                                            ) * 1.0
+                                        );
+                                      }
+                                  ),
+                                  color: teamIndex == 0
+                                      ? DuncColors.playoffs
+                                      : DuncColors.pointsMatch,
+                                  barWidth: 1,
+                                  shadow: Shadow(
+                                      color: DuncColors.notSelectableText.withAlpha(41),
+                                      offset: const Offset(0, 10)
+                                  ),
+                                );
+                              }
+                            ),
+                          titlesData: FlTitlesData(
+                            leftTitles: AxisTitles(
+                              sideTitles: SideTitles(
+                                showTitles: true,
+                                reservedSize: 21,
+                                interval: 20,
+                                getTitlesWidget: (value, meta) => Text(
+                                  value.toInt().toString(),
+                                  style: const TextStyle(
+                                    color: DuncColors.notSelectableText,
+                                    fontFamily: 'Lexend',
+                                    fontWeight: FontWeight.w400,
+                                    fontSize: 12
+                                  ),
+                                )
+                              )
+                            ),
+                            rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false,)),
+                            bottomTitles: AxisTitles(
+                              sideTitles: SideTitles(
+                                showTitles: true,
+                                reservedSize: 30,
+                                interval: 2,
+                                getTitlesWidget: (value, meta) => Flexible(
+                                  child: Column(
+                                    mainAxisAlignment: MainAxisAlignment.center,
+                                    children: [Text(
+                                      'Q${value ~/ 2 + 1}',
+                                      style: const TextStyle(
+                                          color: DuncColors.notSelectableText,
+                                          fontFamily: 'Lexend',
+                                          fontWeight: FontWeight.w400,
+                                          fontSize: 12
+                                      ),
+                                    )],
+                                  ),
+                                )                              )
                             )
+                          )
                         )
                     ),
                   );

--- a/lib/tools/colors.dart
+++ b/lib/tools/colors.dart
@@ -50,4 +50,6 @@ class DuncColors {
 
   // 比賽詳細資訊
   static const Color matchInfo = Color(0xff707585);
+  // 無選文字
+  static const Color notSelectableText = Color(0xff8a8989);
 }

--- a/lib/tools/colors.dart
+++ b/lib/tools/colors.dart
@@ -49,5 +49,5 @@ class DuncColors {
   static const Color shadowDark  = Color(0xffb0b0b0);
 
   // 比賽詳細資訊
-static const Color matchInfo = Color(0xff707585);
+  static const Color matchInfo = Color(0xff707585);
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -50,13 +50,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.4"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.3"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
+  fl_chart:
+    dependency: "direct main"
+    description:
+      name: fl_chart
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.50.6"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -101,7 +115,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -115,7 +129,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -127,7 +141,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -162,21 +176,14 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.9"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.16.2 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=1.13.18"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_neumorphic: ^3.0.3
+  fl_chart: ^0.50.6
 
 
   # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
影響全局：
- 執行pub update
- 增加dependency: fl_chart以用來繪製圖表

搜尋頁：比賽詳情：
- 尚未建立毛玻璃，暫時以黑框代替
- 這一頁有用到Navigator.pop以及page route。請 @allenw415 注意
- 如果要調整數據，可以到example_match.dart玩玩