### PR TITLE
搜尋頁更新

### DIFF
--- a/lib/search_page/match.dart
+++ b/lib/search_page/match.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_neumorphic/flutter_neumorphic.dart';
 import '../tools/colors.dart';
 
-List<Widget> matchWidgets(double screenWidth){
+List<Widget> matchWidgets(){
   return <Widget>[]; //todo
 }

--- a/lib/search_page/match_info.dart
+++ b/lib/search_page/match_info.dart
@@ -297,15 +297,16 @@ List<Widget> _summary(final Match match){
                     width: boxConstrains.maxWidth - 96,
                     child: LineChart(
                         LineChartData(
-                          // 實際的資料點
+                          // 資料點
                           lineBarsData: List.generate(
                               2,  // two teams
                               (teamIndex) {
                                 return LineChartBarData(
+                                  // xy值
                                   spots: List.generate(
-                                      teamIndex == 0 ?
-                                      match.quarterScore1?.length ?? 0 : // return the value if it isn't null
-                                      match.quarterScore2?.length ?? 0,
+                                      teamIndex == 0
+                                        ? match.quarterScore1?.length ?? 0  // return the value if it isn't null
+                                        : match.quarterScore2?.length ?? 0,
                                       (quarterIndex){
                                         return FlSpot(
                                             quarterIndex * 1.0,
@@ -324,8 +325,20 @@ List<Widget> _summary(final Match match){
                                       color: DuncColors.notSelectableText.withAlpha(41),
                                       offset: const Offset(0, 10)
                                   ),
+                                  // 資料點樣式
+                                  dotData: FlDotData(
+                                    getDotPainter: (_, __, ___, ____) => FlDotCirclePainter(
+                                      color: DuncColors.mainBackground,
+                                      radius: 1.5,
+                                      strokeColor: teamIndex == 0
+                                        ? DuncColors.playoffs
+                                        : DuncColors.pointsMatch,
+                                      strokeWidth: 1.5
+                                    )
+                                  ),
                                 );
-                              }
+                              },
+                              growable: false
                             ),
                           titlesData: FlTitlesData(
                             leftTitles: AxisTitles(
@@ -375,11 +388,24 @@ List<Widget> _summary(final Match match){
                             show: true,
                             border: Border(
                               bottom: BorderSide(
-                                color: DuncColors.notSelectableText.withAlpha(31),
+                                color: DuncColors.notSelectableText.withAlpha(41),
                                 width: 1
                               )
                             )
-                          )
+                          ),
+                          // 點擊資料點後的樣式
+                          lineTouchData: LineTouchData(
+                            enabled: true,
+                            touchTooltipData: LineTouchTooltipData(
+                              tooltipBgColor: Colors.white,
+                              tooltipPadding: const EdgeInsets.all(12),
+                              tooltipRoundedRadius: 8,
+                            ),
+                          ),
+                          minX: 0,
+                          minY: 0,
+                          // 資料點的對齊線
+                          gridData: FlGridData(show: false),
                         )
                     ),
                   );

--- a/lib/search_page/match_info.dart
+++ b/lib/search_page/match_info.dart
@@ -24,6 +24,7 @@ class _MatchInfoState extends State<MatchInfo> {
     // id toward one single match
     final id = ModalRoute.of(context)!.settings.arguments as String;
     final match = matches[id]!;
+    
     return Scaffold(
       backgroundColor: DuncColors.mainBackground,
       appBar: AppBar(
@@ -258,6 +259,7 @@ List<Widget> _summary(final Match match){
     fontWeight: FontWeight.w600,
     fontSize: 15
   );
+
   Container summaryTitle(final String title){
     return Container(
       alignment: Alignment.topLeft,
@@ -274,6 +276,7 @@ List<Widget> _summary(final Match match){
       ),
     );
   }
+
   return [
     // 各節比分
     Neumorphic(
@@ -345,22 +348,36 @@ List<Widget> _summary(final Match match){
                             bottomTitles: AxisTitles(
                               sideTitles: SideTitles(
                                 showTitles: true,
-                                reservedSize: 30,
+                                reservedSize: 33,
                                 interval: 2,
                                 getTitlesWidget: (value, meta) => Flexible(
                                   child: Column(
-                                    mainAxisAlignment: MainAxisAlignment.center,
-                                    children: [Text(
-                                      'Q${value ~/ 2 + 1}',
-                                      style: const TextStyle(
-                                          color: DuncColors.notSelectableText,
-                                          fontFamily: 'Lexend',
-                                          fontWeight: FontWeight.w400,
-                                          fontSize: 12
+                                    children: [
+                                      const Spacer(),
+                                      Text(
+                                        'Q${value ~/ 2 + 1}',
+                                        style: const TextStyle(
+                                            color: DuncColors.notSelectableText,
+                                            fontFamily: 'Lexend',
+                                            fontWeight: FontWeight.w400,
+                                            fontSize: 12
+                                        ),
                                       ),
-                                    )],
+                                      const Spacer(flex: 2,)
+                                    ],
                                   ),
-                                )                              )
+                                )
+                              )
+                            ),
+                            topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false))
+                          ),
+                          borderData: FlBorderData(
+                            show: true,
+                            border: Border(
+                              bottom: BorderSide(
+                                color: DuncColors.notSelectableText.withAlpha(31),
+                                width: 1
+                              )
                             )
                           )
                         )

--- a/lib/search_page/match_info.dart
+++ b/lib/search_page/match_info.dart
@@ -67,7 +67,6 @@ class _MatchInfoState extends State<MatchInfo> {
         children: [
           // toggle上方的所有物件
           Container(
-            width: MediaQuery.of(context).size.width,
             height: 151,
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.center,

--- a/lib/search_page/search_view.dart
+++ b/lib/search_page/search_view.dart
@@ -4,8 +4,6 @@ import '../tools/colors.dart';
 import './team.dart';
 import './match.dart';
 
-double? screenWidth; // set in build of _SearchViewState
-double? screenHeight; // set in build of _SearchViewState
 int searchTeamOrMatchToggleIndex = 0;
 
 class SearchView extends StatefulWidget {
@@ -26,8 +24,6 @@ class _SearchViewState extends State<SearchView> {
 
   @override
   Widget build(BuildContext context) {
-    screenWidth = MediaQuery.of(context).size.width;
-    screenHeight = MediaQuery.of(context).size.height;
     return Scaffold(
       backgroundColor: DuncColors.mainBackground,
       body: Column(
@@ -98,8 +94,8 @@ class _SearchViewState extends State<SearchView> {
               )),
         ] +
             (searchTeamOrMatchToggleIndex == 0
-                ? teamWidgets(searchTeamTextCtrl, screenWidth!, screenHeight!, this)
-                : matchWidgets(screenWidth!)),
+                ? teamWidgets(searchTeamTextCtrl, this)
+                : matchWidgets()),
       ),
     );
   }

--- a/lib/search_page/team.dart
+++ b/lib/search_page/team.dart
@@ -18,74 +18,74 @@ Set<String> _teamTrack = {};
 
 List<Widget> teamWidgets(
     TextEditingController searchTextCtrl,
-    double screenWidth,
-    double screenHeight,
     State searchViewState
   )
 {
   return [
     // 搜尋欄
-    Stack(
-      alignment: Alignment.center,
-      children: [
-        // 漸層外框
-        Container(
-          height: 57,
-          width: screenWidth - 110,
-          decoration: const BoxDecoration(
-            gradient: LinearGradient(
-              begin: Alignment.topRight,
-              end: Alignment.bottomLeft,
-              colors: [DuncColors.mainCTAFrom, DuncColors.mainCTATo]
-            ),
-            borderRadius: BorderRadius.all(Radius.circular(40))
-          ),
-        ),
-        // 輸入框
-        Container(
-          height: 51,
-          width: screenWidth - 116,
-          decoration: const BoxDecoration(
-            borderRadius: BorderRadius.all(Radius.circular(40)),
-            color: DuncColors.mainBackground
-          ),
-          alignment: Alignment.center,
-          child: TextField(
-            decoration: InputDecoration(
-                border: InputBorder.none,
-                hintStyle: const TextStyle(color: DuncColors.indicatorImportant),  //todo: 提示文字要不要暗點？
-                hintText: "輸入球隊或球員名稱",
-                // 搜尋按鈕的漸層
-                suffixIcon: ShaderMask(
-                  shaderCallback: (bounds) => const LinearGradient(
+    LayoutBuilder(
+      builder: (context, constraint) => Stack(
+        alignment: Alignment.center,
+        children: [
+          // 漸層外框
+          Container(
+            height: 57,
+            width: constraint.maxWidth - 110,
+            decoration: const BoxDecoration(
+                gradient: LinearGradient(
                     begin: Alignment.topRight,
                     end: Alignment.bottomLeft,
-                    colors: [DuncColors.mainCTAFrom, DuncColors.mainCTATo],
-                  ).createShader(bounds),
-                  child: const Icon(
-                    Icons.search,
-                    size: 25,
-                    color: Colors.white,  //required for gradient applying
-                  ),
+                    colors: [DuncColors.mainCTAFrom, DuncColors.mainCTATo]
                 ),
-                contentPadding: const EdgeInsets.only(top: 11, left: 23)
+                borderRadius: BorderRadius.all(Radius.circular(40))
             ),
-            keyboardType: TextInputType.name,
-            textInputAction: TextInputAction.search,
-            cursorColor: DuncColors.mainCTATo,
-            style: const TextStyle(
-              fontFamily: "Lexend",
-              fontSize: 16,
-              fontWeight: FontWeight.w700,
-              color: DuncColors.indicatorImportant
-            ),
-            controller: searchTextCtrl,
-            onChanged: (str) {
-              searchTextCtrl.text = str;
-            }, //todo: 要可以真的搜尋
           ),
-        )
-      ],
+          // 輸入框
+          Container(
+            height: 51,
+            width: constraint.maxWidth - 116,
+            decoration: const BoxDecoration(
+                borderRadius: BorderRadius.all(Radius.circular(40)),
+                color: DuncColors.mainBackground
+            ),
+            alignment: Alignment.center,
+            child: TextField(
+              decoration: InputDecoration(
+                  border: InputBorder.none,
+                  hintStyle: const TextStyle(color: DuncColors.indicatorImportant),  //todo: 提示文字要不要暗點？
+                  hintText: "輸入球隊或球員名稱",
+                  // 搜尋按鈕的漸層
+                  suffixIcon: ShaderMask(
+                    shaderCallback: (bounds) => const LinearGradient(
+                      begin: Alignment.topRight,
+                      end: Alignment.bottomLeft,
+                      colors: [DuncColors.mainCTAFrom, DuncColors.mainCTATo],
+                    ).createShader(bounds),
+                    child: const Icon(
+                      Icons.search,
+                      size: 25,
+                      color: Colors.white,  //required for gradient applying
+                    ),
+                  ),
+                  contentPadding: const EdgeInsets.only(top: 11, left: 23)
+              ),
+              keyboardType: TextInputType.name,
+              textInputAction: TextInputAction.search,
+              cursorColor: DuncColors.mainCTATo,
+              style: const TextStyle(
+                  fontFamily: "Lexend",
+                  fontSize: 16,
+                  fontWeight: FontWeight.w700,
+                  color: DuncColors.indicatorImportant
+              ),
+              controller: searchTextCtrl,
+              onChanged: (str) {
+                searchTextCtrl.text = str;
+              }, //todo: 要可以真的搜尋
+            ),
+          )
+        ],
+      ),
     ),
     const SizedBox(height: 48,),
     // 排名、追蹤文字
@@ -115,108 +115,112 @@ List<Widget> teamWidgets(
       ],
     ),
     // 各個科系的排名
-    SizedBox(
-      height: screenHeight - 107 - 57 - 51 - 17,  //todo: 高度到底部。但是以後一定會爆
-      child: ListView.builder(
-        padding: const EdgeInsets.only(top: 10),
-        itemCount: 2 * _rankTeam.length,
-        itemBuilder: (context, i){
-          if(i == _rankTeam.length * 2 - 1){
-            return Column(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: const [
-                Text(
-                  '-無更多隊伍-',
-                  style: TextStyle(
-                    color: DuncColors.indicatorImportant,
-                    fontSize: 20,
-                    fontWeight: FontWeight.w300,
-                    fontFamily: 'Lexend',
-                    height: 5,
-                    letterSpacing: 5
-                  ),
-                )
-              ],
-            );
-          }
-          if(i.isOdd){
-            return const SizedBox(height: 8,);
-          }
-          final index = i ~/ 2;
-          return SizedBox(
-            height: 57,
-            child: NeumorphicButton(
-              margin: const EdgeInsets.only(top: 6, left: 19, right: 19),
-              padding: const EdgeInsets.only(left: 21, right: 21),
-              style: const NeumorphicStyle(
-                  shape: NeumorphicShape.flat,
-                  lightSource: LightSource.topLeft,
-                  color: DuncColors.mainBackground,
-                  shadowDarkColor: DuncColors.shadowDark,
-                  shadowLightColor: DuncColors.shadowLight,
-                  depth: 4
-              ),
-              child: Row(
-                children: [
-                  Text(
-                    '#${index+1}',
-                    style: const TextStyle(
-                        color: DuncColors.indicatorImportant,
-                        fontSize: 20,
-                        fontWeight: FontWeight.w700,
-                        fontFamily: "Noto Sans TC"
-                    ),
-                  ),
-                  const Spacer(),
-                  Text(
-                    _rankTeam[index]!,
-                    style: const TextStyle(
-                      color: DuncColors.indicatorImportant,
-                      fontSize: 24,
-                      fontWeight: FontWeight.w700,
-                      fontFamily: 'Noto Sans TC'
-                    ),
-                  ),
-                  const Spacer(),
-                  NeumorphicButton(
-                    style: const NeumorphicStyle(
-                      disableDepth: true,
-                      color: DuncColors.mainBackground
-                    ),
-                    // 搜尋按鈕的漸層
-                    child: ShaderMask(
-                      shaderCallback: (bounds) => const LinearGradient(
-                        begin: Alignment.topRight,
-                        end: Alignment.bottomLeft,
-                        colors: [DuncColors.mainCTAFrom, DuncColors.mainCTATo],
-                      ).createShader(bounds),
-                      child: Icon(
-                        // todo:追蹤中的icon不太一樣
-                        _teamTrack.contains(_rankTeam[index])
-                            ? Icons.subscriptions
-                            : Icons.subscriptions_outlined,
-                        size: 25,
-                        color: Colors.white,  //required for gradient applying
+    Flexible(
+      child: LayoutBuilder(
+        builder: (context, constraint) => SizedBox(
+          height: constraint.maxHeight,
+          child: ListView.builder(
+            padding: const EdgeInsets.only(top: 10),
+            itemCount: 2 * _rankTeam.length,
+            itemBuilder: (context, i){
+              if(i == _rankTeam.length * 2 - 1){
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: const [
+                    Text(
+                      '-無更多隊伍-',
+                      style: TextStyle(
+                          color: DuncColors.indicatorImportant,
+                          fontSize: 20,
+                          fontWeight: FontWeight.w300,
+                          fontFamily: 'Lexend',
+                          height: 5,
+                          letterSpacing: 5
                       ),
-                    ),
-                    onPressed: (){
-                      searchViewState.setState((){
-                        if(_teamTrack.contains(_rankTeam[index]!)){
-                          _teamTrack.remove(_rankTeam[index]!);
-                        }else{
-                          _teamTrack.add(_rankTeam[index]!);
-                        }
-                      });
-                    },
-                  )
-                ],
-              ),
-              onPressed: (){
-                //todo:
-              },
-            ),
-          );
-        },
+                    )
+                  ],
+                );
+              }
+              if(i.isOdd){
+                return const SizedBox(height: 8,);
+              }
+              final index = i ~/ 2;
+              return SizedBox(
+                height: 57,
+                child: NeumorphicButton(
+                  margin: const EdgeInsets.only(top: 6, left: 19, right: 19),
+                  padding: const EdgeInsets.only(left: 21, right: 21),
+                  style: const NeumorphicStyle(
+                      shape: NeumorphicShape.flat,
+                      lightSource: LightSource.topLeft,
+                      color: DuncColors.mainBackground,
+                      shadowDarkColor: DuncColors.shadowDark,
+                      shadowLightColor: DuncColors.shadowLight,
+                      depth: 4
+                  ),
+                  child: Row(
+                    children: [
+                      Text(
+                        '#${index+1}',
+                        style: const TextStyle(
+                            color: DuncColors.indicatorImportant,
+                            fontSize: 20,
+                            fontWeight: FontWeight.w700,
+                            fontFamily: "Noto Sans TC"
+                        ),
+                      ),
+                      const Spacer(),
+                      Text(
+                        _rankTeam[index]!,
+                        style: const TextStyle(
+                            color: DuncColors.indicatorImportant,
+                            fontSize: 24,
+                            fontWeight: FontWeight.w700,
+                            fontFamily: 'Noto Sans TC'
+                        ),
+                      ),
+                      const Spacer(),
+                      NeumorphicButton(
+                        style: const NeumorphicStyle(
+                            disableDepth: true,
+                            color: DuncColors.mainBackground
+                        ),
+                        // 搜尋按鈕的漸層
+                        child: ShaderMask(
+                          shaderCallback: (bounds) => const LinearGradient(
+                            begin: Alignment.topRight,
+                            end: Alignment.bottomLeft,
+                            colors: [DuncColors.mainCTAFrom, DuncColors.mainCTATo],
+                          ).createShader(bounds),
+                          child: Icon(
+                            // todo:追蹤中的icon不太一樣
+                            _teamTrack.contains(_rankTeam[index])
+                                ? Icons.subscriptions
+                                : Icons.subscriptions_outlined,
+                            size: 25,
+                            color: Colors.white,  //required for gradient applying
+                          ),
+                        ),
+                        onPressed: (){
+                          searchViewState.setState((){
+                            if(_teamTrack.contains(_rankTeam[index]!)){
+                              _teamTrack.remove(_rankTeam[index]!);
+                            }else{
+                              _teamTrack.add(_rankTeam[index]!);
+                            }
+                          });
+                        },
+                      )
+                    ],
+                  ),
+                  onPressed: (){
+                    //todo:
+                  },
+                ),
+              );
+            },
+          ),
+        ),
       ),
     ),
   ];

--- a/lib/search_page/team.dart
+++ b/lib/search_page/team.dart
@@ -82,7 +82,7 @@ List<Widget> teamWidgets(
             controller: searchTextCtrl,
             onChanged: (str) {
               searchTextCtrl.text = str;
-            }, //todo
+            }, //todo: 要可以真的搜尋
           ),
         )
       ],
@@ -93,7 +93,7 @@ List<Widget> teamWidgets(
       children: const [
         SizedBox(width: 36,),
         Text(
-            '排名',
+          '排名',
           style: TextStyle(
             color: DuncColors.indicatorImportant,
             fontSize: 14,
@@ -116,7 +116,7 @@ List<Widget> teamWidgets(
     ),
     // 各個科系的排名
     SizedBox(
-      height: screenHeight - 107 - 57 - 51 - 17,  // 高度到底部。但是以後一定會爆
+      height: screenHeight - 107 - 57 - 51 - 17,  //todo: 高度到底部。但是以後一定會爆
       child: ListView.builder(
         padding: const EdgeInsets.only(top: 10),
         itemCount: 2 * _rankTeam.length,


### PR DESCRIPTION
搜尋頁：全部
- 搜尋頁的頁面改以Flexible、LayoutBuilder去計算Widget的大小，因為這樣就不用考慮其他Widget的大小了。請 @allenw415 注意

- known bug
  - 搜尋頁：比賽詳情
    - 各節比賽的圖表在點擊後所出現的彈出框尚無法與Figma相同，好像沒找到可以用的參數
    - 尚未建立上方的毛玻璃，暫時以黑框代替